### PR TITLE
doc_name change API

### DIFF
--- a/documents/resources.py
+++ b/documents/resources.py
@@ -37,7 +37,10 @@ def update_documents(document_id, payload):
         return jsonify({'message':'unauthorized request.'}), 400
     if data_from_user == "" or data_from_user == None:
         jsonify({'message':'Data updated already.'}), 400
-    state_machine.update_document_by_document_id(document_id, data_from_user)
+    if 'name' in data:
+        state_machine.update_document_by_document_id(document_id, data_from_user, data['name'])
+    else:
+        state_machine.update_document_data_by_document_id(document_id, data_from_user)
     return jsonify({'message':'Data saved.'}), 200
 
 @documents.route('/<document_id>', methods=['GET'])

--- a/documents/state_machine.py
+++ b/documents/state_machine.py
@@ -37,7 +37,14 @@ def get_all_documents_by_user_id(user_id):
         document_id_array.append({'id':vars(document)['id'], 'name':vars(document)['name']})
     return document_id_array
 
-def update_document_by_document_id(document_id, data_from_user):
+def update_document_by_document_id(document_id, data_from_user, doc_name_from_user):
+    document = db.session.query(Document).filter(Document.id == document_id).first()
+    document.data = data_from_user
+    document.name = doc_name_from_user
+    db.session.commit()
+    return {'data updated'}
+
+def update_document_data_by_document_id(document_id, data_from_user):
     document = db.session.query(Document).filter(Document.id == document_id).first()
     document.data = data_from_user
     db.session.commit()


### PR DESCRIPTION
### In this PR:
1. Have updated the API to add data from user to db and added a new 'name' param to change the name of the document
2. Configured the API in such a way that if the name param exists or not, the API will still work with just the document data and not crash