### PR TITLE
document collaboration

### DIFF
--- a/documents/resources.py
+++ b/documents/resources.py
@@ -1,4 +1,5 @@
 import documents.state_machine as state_machine
+from sendgrid_helper import send_invite_email
 import utils
 from flask import jsonify, request, Blueprint
 
@@ -31,10 +32,13 @@ def get_documents(payload):
 def update_documents(document_id, payload):
     data = request.get_json()
     data_from_user = data['data']
-    user_id_from_authorization_header = payload['user_id']
     user_id_from_document_id = str(state_machine.get_document_by_id(document_id).user_id)
+    user_id_from_authorization_header = payload['user_id']
     if user_id_from_authorization_header != user_id_from_document_id:
-        return jsonify({'message':'unauthorized request.'}), 400
+        email_from_user_id = state_machine.get_user_by_user_id(user_id_from_authorization_header)['email']
+        shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, email_from_user_id)
+        if shared_document_row is None:
+            return jsonify({'message':'unauthorized request.'}), 400
     if data_from_user == "" or data_from_user == None:
         jsonify({'message':'Data updated already.'}), 400
     if 'name' in data:
@@ -45,11 +49,50 @@ def update_documents(document_id, payload):
 
 @documents.route('/<document_id>', methods=['GET'])
 @utils.server_error_check
-@utils.authorize_user
-def get_document_data(document_id, payload):
-    user_id_from_authorization_header = payload['user_id']
+def get_document_data(document_id):
     document_row = state_machine.get_document_by_id(document_id)
-    user_id_from_document_id = str(document_row.user_id)
-    if user_id_from_authorization_header != user_id_from_document_id:
+    user_id_from_document_row = str(document_row.user_id)
+    document_owner_email = state_machine.get_user_by_user_id(user_id_from_document_row)['email']
+    owner_shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, document_owner_email)
+    if owner_shared_document_row is None:
         return jsonify({'message':'unauthorized request.'}), 400
-    return jsonify(document_row.__serialize__()), 200
+    if owner_shared_document_row.public == True:
+        return jsonify(document_row.__serialize__()), 200
+    auth_header = request.headers.get('Authorization')
+    if auth_header is None:
+        return jsonify({'message':'unauthorized request.'}), 400
+    payload = utils.token_valid_check(auth_header)
+    user_id_from_authorization_header = payload['user_id']
+    if user_id_from_authorization_header == user_id_from_document_row:
+        return jsonify(document_row.__serialize__()), 200
+    email_from_user_id = state_machine.get_user_by_user_id(user_id_from_authorization_header)['email']
+    shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, email_from_user_id)
+    if shared_document_row is not None:
+        return jsonify(document_row.__serialize__()), 200
+    else:
+        return jsonify({'message':'unauthorized request.'}), 400
+
+@documents.route('/<document_id>/share', methods=['POST'])
+@utils.server_error_check
+@utils.authorize_user
+def share_document(document_id, payload):
+    data = request.get_json()
+    shared_user_email = data['email'] 
+    user_id = payload['user_id']
+    document_row = state_machine.get_document_by_id(document_id)
+    if user_id != str(document_row.user_id):
+        return jsonify({'message':'unauthorized request.'}), 400
+    shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, shared_user_email)
+    if shared_document_row is not None:
+        if 'public' in data:
+            state_machine.update_shared_document(document_id, shared_user_email, data['public'])
+            return jsonify({'message':'updated shared document.'})
+        return jsonify({'message':'document shared already.'}), 400
+    user_row = state_machine.get_user_by_email(shared_user_email)
+    if user_row is None:
+        send_invite_email(shared_user_email)
+    if 'public' in data:
+        state_machine.upsert_shared_document_with_public(document_id, shared_user_email, data['public'])    
+    else:
+        state_machine.upsert_shared_document(document_id, shared_user_email)    
+    return jsonify({'message':'Document shared.'}), 200

--- a/documents/resources.py
+++ b/documents/resources.py
@@ -22,7 +22,7 @@ def get_documents(payload):
     args = request.args
     user_id = args.get('user_id')
     if user_id != user_id_from_authorization_header:
-        return jsonify({'message':'unauthorized request.'}), 400
+        return jsonify({'message':'unauthorized request.'}), 403
     document_id_array = state_machine.get_all_documents_by_user_id(user_id)
     return jsonify(document_id_array), 200
 
@@ -38,7 +38,7 @@ def update_documents(document_id, payload):
         email_from_user_id = state_machine.get_user_by_user_id(user_id_from_authorization_header)['email']
         shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, email_from_user_id)
         if shared_document_row is None:
-            return jsonify({'message':'unauthorized request.'}), 400
+            return jsonify({'message':'unauthorized request.'}), 403
     if data_from_user == "" or data_from_user == None:
         jsonify({'message':'Data updated already.'}), 400
     if 'name' in data:
@@ -55,12 +55,12 @@ def get_document_data(document_id):
     document_owner_email = state_machine.get_user_by_user_id(user_id_from_document_row)['email']
     owner_shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, document_owner_email)
     if owner_shared_document_row is None:
-        return jsonify({'message':'unauthorized request.'}), 400
+        return jsonify({'message':'unauthorized request.'}), 403
     if owner_shared_document_row.public == True:
         return jsonify(document_row.__serialize__()), 200
     auth_header = request.headers.get('Authorization')
     if auth_header is None:
-        return jsonify({'message':'unauthorized request.'}), 400
+        return jsonify({'message':'unauthorized request.'}), 403
     payload = utils.token_valid_check(auth_header)
     user_id_from_authorization_header = payload['user_id']
     if user_id_from_authorization_header == user_id_from_document_row:
@@ -70,7 +70,7 @@ def get_document_data(document_id):
     if shared_document_row is not None:
         return jsonify(document_row.__serialize__()), 200
     else:
-        return jsonify({'message':'unauthorized request.'}), 400
+        return jsonify({'message':'unauthorized request.'}), 403
 
 @documents.route('/<document_id>/share', methods=['POST'])
 @utils.server_error_check
@@ -81,7 +81,7 @@ def share_document(document_id, payload):
     user_id = payload['user_id']
     document_row = state_machine.get_document_by_id(document_id)
     if user_id != str(document_row.user_id):
-        return jsonify({'message':'unauthorized request.'}), 400
+        return jsonify({'message':'unauthorized request.'}), 403
     shared_document_row = state_machine.get_shared_document_by_id_and_email(document_id, shared_user_email)
     if shared_document_row is not None:
         if 'public' in data:

--- a/documents/state_machine.py
+++ b/documents/state_machine.py
@@ -1,7 +1,7 @@
 from models.db import db
 from models.User import User
 from models.Document import Document
-from models.Shared_document import Shared_document
+from models.SharedDocument import SharedDocument
 
 def get_user_by_user_id(user_id):
     users = db.session.query(User).filter(User.id == user_id)
@@ -61,34 +61,34 @@ def update_document_data_by_document_id(document_id, data_from_user):
     return {'data updated'}
 
 def upsert_shared_document(document_id, email):
-    shared_document = Shared_document(
+    shared_document = SharedDocument(
         document_id = document_id,
         email = email
     )
     db.session.add(shared_document)
     db.session.commit()
-    document_row = db.session.query(Shared_document).filter(Shared_document.id == shared_document.id).first()
+    document_row = db.session.query(SharedDocument).filter(SharedDocument.id == shared_document.id).first()
     return document_row
 
 def upsert_shared_document_with_public(document_id, email, public):
-    shared_document = Shared_document(
+    shared_document = SharedDocument(
         document_id = document_id,
         email = email,
         public = public
     )
     db.session.add(shared_document)
     db.session.commit()
-    document_row = db.session.query(Shared_document).filter(Shared_document.id == shared_document.id).first()
+    document_row = db.session.query(SharedDocument).filter(SharedDocument.id == shared_document.id).first()
     return document_row
 
 def update_shared_document(document_id, email, public):
-    shared_document = db.session.query(Shared_document).filter(Shared_document.document_id == document_id, Shared_document.email == email).first()
+    shared_document = db.session.query(SharedDocument).filter(SharedDocument.document_id == document_id, SharedDocument.email == email).first()
     shared_document.public = public
     db.session.commit()
     return {'data updated'}
 
 def get_shared_document_by_id_and_email(id, email):
-    shared_document = db.session.query(Shared_document).filter(Shared_document.document_id == id, Shared_document.email == email)
+    shared_document = db.session.query(SharedDocument).filter(SharedDocument.document_id == id, SharedDocument.email == email)
     if shared_document.count() <= 0:
         return None
     if shared_document.count() == 1:

--- a/documents/state_machine.py
+++ b/documents/state_machine.py
@@ -1,6 +1,7 @@
 from models.db import db
 from models.User import User
 from models.Document import Document
+from models.Shared_document import Shared_document
 
 def get_user_by_user_id(user_id):
     users = db.session.query(User).filter(User.id == user_id)
@@ -9,6 +10,15 @@ def get_user_by_user_id(user_id):
     if users.count() == 1:
         for i in users:
             return vars(i)
+    if users.count() > 1:
+        raise Exception({'error':'voilates the unique ability!'})
+
+def get_user_by_email(email):
+    users = db.session.query(User).filter(User.email == email)
+    if users.count() <= 0:
+        return None
+    if users.count() == 1:
+        return users[0]
     if users.count() > 1:
         raise Exception({'error':'voilates the unique ability!'})
     
@@ -49,3 +59,39 @@ def update_document_data_by_document_id(document_id, data_from_user):
     document.data = data_from_user
     db.session.commit()
     return {'data updated'}
+
+def upsert_shared_document(document_id, email):
+    shared_document = Shared_document(
+        document_id = document_id,
+        email = email
+    )
+    db.session.add(shared_document)
+    db.session.commit()
+    document_row = db.session.query(Shared_document).filter(Shared_document.id == shared_document.id).first()
+    return document_row
+
+def upsert_shared_document_with_public(document_id, email, public):
+    shared_document = Shared_document(
+        document_id = document_id,
+        email = email,
+        public = public
+    )
+    db.session.add(shared_document)
+    db.session.commit()
+    document_row = db.session.query(Shared_document).filter(Shared_document.id == shared_document.id).first()
+    return document_row
+
+def update_shared_document(document_id, email, public):
+    shared_document = db.session.query(Shared_document).filter(Shared_document.document_id == document_id, Shared_document.email == email).first()
+    shared_document.public = public
+    db.session.commit()
+    return {'data updated'}
+
+def get_shared_document_by_id_and_email(id, email):
+    shared_document = db.session.query(Shared_document).filter(Shared_document.document_id == id, Shared_document.email == email)
+    if shared_document.count() <= 0:
+        return None
+    if shared_document.count() == 1:
+        return shared_document[0]
+    if shared_document.count() > 1:
+        raise Exception({'error':'voilates the unique ability!'})

--- a/models/SharedDocument.py
+++ b/models/SharedDocument.py
@@ -5,7 +5,7 @@ from models.db import db
 from sqlalchemy.dialects.postgresql.base import UUID
 from sqlalchemy.dialects.postgresql import JSON
 
-class Shared_document(db.Model):
+class SharedDocument(db.Model):
     __tablename__ = 'shared_documents'
     id = db.Column(UUID(as_uuid=True), primary_key=True, unique=True, server_default=sqlalchemy.text("uuid_generate_v4()"),)
     document_id = db.Column(UUID(as_uuid=True), sqlalchemy.ForeignKey(Document.id), unique=False, nullable=False)

--- a/models/Shared_document.py
+++ b/models/Shared_document.py
@@ -1,0 +1,28 @@
+import json
+import sqlalchemy
+from models.Document import Document
+from models.db import db
+from sqlalchemy.dialects.postgresql.base import UUID
+from sqlalchemy.dialects.postgresql import JSON
+
+class Shared_document(db.Model):
+    __tablename__ = 'shared_documents'
+    id = db.Column(UUID(as_uuid=True), primary_key=True, unique=True, server_default=sqlalchemy.text("uuid_generate_v4()"),)
+    document_id = db.Column(UUID(as_uuid=True), sqlalchemy.ForeignKey(Document.id), unique=False, nullable=False)
+    email = db.Column(db.String(255), unique=False, nullable=False)
+    public = db.Column(sqlalchemy.Boolean, unique=False, nullable=True)
+    created_at = db.Column(db.DateTime(), nullable=False, server_default=db.func.now())
+    updated_at = db.Column(db.DateTime(), nullable=False, server_default=db.func.now(), server_onupdate=db.func.now())
+
+    def __serialize__(self):
+        document_row = {"id": self.id, "document_id": self.document_id, "email": self.email, "public":self.public, "created_at": self.created_at, "updated_at": self.updated_at}
+        serialized_row = json.dumps(document_row, default=str)
+        return serialized_row
+
+def __init__(self, id, document_id, email, public, created_at, updated_at):
+    self.id = id
+    self.document_id = document_id
+    self.email = email
+    self.public = public
+    self.created_at = created_at
+    self.updated_at = updated_at

--- a/sendgrid_helper.py
+++ b/sendgrid_helper.py
@@ -19,3 +19,19 @@ def send_reset_password_mail(email, token):
             raise Exception({'error':'please try again later'})            
     except Exception as e:
         raise Exception({'error':str(e.message)})
+
+def send_invite_email(email):
+    try:
+        from_email = config['SENDGRID_EMAIL']
+        subject = 'Someone shared a document with you on Arc!'
+        content = 'To check the document, sign up to the service here:'
+        html_content = 'To check the document shared, sign up to the service: <a href="https://open-source-notion.manthankumbhar.com">here</a>' 
+        message = Mail(from_email, email, subject, content, html_content)
+        sg = SendGridAPIClient()
+        res = sg.send(message)
+        if res.status_code == 202:
+            return {'success':'email sent!'}
+        else:
+            raise Exception({'error':'please try again later'})            
+    except Exception as e:
+        raise Exception({'error':str(e.message)})


### PR DESCRIPTION
In this PR:
- user can now share documents with another user
- created and connected a new db table 'shared_documents'
- added a new API '/share' which allows the owner to share documents with other emails
- updated the existing API '/documents/<document_id>' to now allow shared users to get and update data + allow data to everyone if document is public